### PR TITLE
🔧 Fix Admin Dashboard - Plan ändern, Löschen und alle Funktionen funk…

### DIFF
--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -217,10 +217,12 @@ export default function AdminDashboard() {
   };
 
   const handleChangePlan = (id: string, currentPlan: string) => {
-    const plans = ['starter', 'professional', 'enterprise', 'free'];
-    const plan = prompt(`Change plan to (${plans.join(', ')}):`, currentPlan);
+    const plans = ['free', 'pro', 'ultra', 'ultimate'];
+    const plan = prompt(`Change plan to (${plans.join(', ')}):`, currentPlan || 'free');
     if (plan && plans.includes(plan.toLowerCase())) {
       changePlanMutation.mutate({ id, plan: plan.toLowerCase(), status: 'active' });
+    } else if (plan) {
+      toast({ title: "❌ Invalid plan", description: `Valid plans: ${plans.join(', ')}`, variant: "destructive" });
     }
   };
 


### PR DESCRIPTION
…tionieren jetzt

- Plan-Namen korrigiert: free, pro, ultra, ultimate (statt starter, professional, enterprise)
- PATCH für Tabellen ohne updatedAt-Spalte repariert
- Sessions-Tabelle: sid statt id als Primary Key verwendet
- Bessere Fehlermeldungen bei ungültigen Eingaben
- Alle CRUD-Operationen funktionieren jetzt korrekt